### PR TITLE
minimal changes for python2 compatibility

### DIFF
--- a/rbo.py
+++ b/rbo.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """Rank-biased overlap, a ragged sorted list similarity measure.
 
 See http://doi.acm.org/10.1145/1852102.1852106 for details. All functions
@@ -128,7 +126,7 @@ def rbo_at_k(list1, list2, p, depth=None):
     # 0
     depth = min(len(list1), len(list2)) if depth is None else depth
     d_a = enumerate(cumulative_agreement(list1, list2, depth))
-    return (1 - p) * sum(p**d * a for (d, a) in d_a)
+    return (1 - p) * sum(p ** d * a for (d, a) in d_a)
 
 
 def rbo_min(list1, list2, p, depth=None):
@@ -145,8 +143,9 @@ def rbo_min(list1, list2, p, depth=None):
     depth = min(len(list1), len(list2)) if depth is None else depth
     x_k = overlap(list1, list2, depth)
     log_term = x_k * math.log(1 - p)
-    sum_term = sum(p**d / d * (overlap(list1, list2, d) - x_k)
-                   for d in range(1, depth + 1))
+    sum_term = sum(
+        p ** d / d * (overlap(list1, list2, d) - x_k) for d in range(1, depth + 1)
+    )
     return (1 - p) / p * (sum_term - log_term)
 
 
@@ -172,10 +171,10 @@ def rbo_res(list1, list2, p):
     # must be an integer --> math.ceil()
     f = int(math.ceil(l + s - x_l))
     # upper bound of range() is non-inclusive, therefore + 1 is needed
-    term1 = s * sum(p**d / d for d in range(s + 1, f + 1))
-    term2 = l * sum(p**d / d for d in range(l + 1, f + 1))
-    term3 = x_l * (math.log(1 / (1 - p)) - sum(p**d / d for d in range(1, f + 1)))
-    return p**s + p**l - p**f - (1 - p) / p * (term1 + term2 + term3)
+    term1 = s * sum(p ** d / d for d in range(s + 1, f + 1))
+    term2 = l * sum(p ** d / d for d in range(l + 1, f + 1))
+    term3 = x_l * (math.log(1 / (1 - p)) - sum(p ** d / d for d in range(1, f + 1)))
+    return p ** s + p ** l - p ** f - (1 - p) / p * (term1 + term2 + term3)
 
 
 def rbo_ext(list1, list2, p):
@@ -199,10 +198,10 @@ def rbo_ext(list1, list2, p):
     # agreement(..., d) defined as per equation (28) so that ties are handled
     # properly (otherwise values > 1 will be returned)
     # sum1 = sum(p**d * overlap(list1, list2, d)[0] / d for d in range(1, l + 1))
-    sum1 = sum(p**d * agreement(list1, list2, d) for d in range(1, l + 1))
-    sum2 = sum(p**d * x_s * (d - s) / s / d for d in range(s + 1, l + 1))
+    sum1 = sum(p ** d * agreement(list1, list2, d) for d in range(1, l + 1))
+    sum2 = sum(p ** d * x_s * (d - s) / s / d for d in range(s + 1, l + 1))
     term1 = (1 - p) / p * (sum1 + sum2)
-    term2 = p**l * ((x_l - x_s) / l + x_s / s)
+    term2 = p ** l * ((x_l - x_s) / l + x_s / s)
     return term1 + term2
 
 
@@ -257,4 +256,5 @@ def rbo_dict(dict1, dict2, p):
 
 if __name__ in ("__main__", "__console__"):
     import doctest
+
     doctest.testmod()

--- a/rbo.py
+++ b/rbo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """Rank-biased overlap, a ragged sorted list similarity measure.
 
@@ -13,6 +13,8 @@ is not mentioned in the paper but seems to be reasonable, see function
 because of this are highlighted with comments.
 
 """
+
+from __future__ import division
 
 import math
 from bisect import bisect_left
@@ -167,8 +169,8 @@ def rbo_res(list1, list2, p):
     s, l = len(S), len(L)
     x_l = overlap(list1, list2, l)
     # since overlap(...) can be fractional in the general case of ties and f
-    # must be an integer → math.ceil()
-    f = math.ceil(l + s - x_l)
+    # must be an integer --> math.ceil()
+    f = int(math.ceil(l + s - x_l))
     # upper bound of range() is non-inclusive, therefore + 1 is needed
     term1 = s * sum(p**d / d for d in range(s + 1, f + 1))
     term2 = l * sum(p**d / d for d in range(l + 1, f + 1))


### PR DESCRIPTION
Hello there, not sure if this is still an active project, but I'm trying it out and unfortunately we're still using python2 over here.  

 - float division future statement
 - remove non-ascii character from comment
 - range() must take integer args

Doctests pass on 2.7 and 3.6.